### PR TITLE
🎨 Palette: Add password visibility toggle

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,0 +1,5 @@
+# Palette's Journal
+
+This journal documents critical UX and accessibility learnings.
+
+## 2025-02-27 - Password Visibility Toggle **Learning:** Adding a password visibility toggle significantly improves usability by preventing typing errors, especially on mobile devices where typing is more prone to mistakes. It's a small change with high impact. **Action:** Always consider adding password visibility toggles to password input fields in future forms.

--- a/src/frontend/src/app/home/home.component.spec.ts
+++ b/src/frontend/src/app/home/home.component.spec.ts
@@ -1,5 +1,5 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
-
+import { provideRouter } from '@angular/router';
 import { HomeComponent } from './home.component';
 
 describe('HomeComponent', () => {
@@ -8,7 +8,8 @@ describe('HomeComponent', () => {
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      imports: [HomeComponent]
+      imports: [HomeComponent],
+      providers: [provideRouter([])]
     }).compileComponents();
 
     fixture = TestBed.createComponent(HomeComponent);

--- a/src/frontend/src/app/login/login.component.html
+++ b/src/frontend/src/app/login/login.component.html
@@ -26,7 +26,18 @@
 			</label>
 			<label class="field">
 				<span>Password</span>
-				<input type="password" name="password" [(ngModel)]="password" placeholder="••••••••" autocomplete="current-password" required [disabled]="loading">
+				<div class="relative w-full">
+					<input [type]="showPassword ? 'text' : 'password'" name="password" [(ngModel)]="password" placeholder="••••••••" autocomplete="current-password" required [disabled]="loading" class="w-full">
+					<button type="button" (click)="togglePassword()" [attr.aria-label]="showPassword ? 'Hide password' : 'Show password'" class="absolute right-3 top-1/2 -translate-y-1/2 bg-transparent border-0 cursor-pointer text-slate-400/60 p-1">
+						<svg *ngIf="!showPassword" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-5 h-5">
+							<path stroke-linecap="round" stroke-linejoin="round" d="M2.036 12.322a1.012 1.012 0 010-.639C3.423 7.51 7.36 4.5 12 4.5c4.638 0 8.573 3.007 9.963 7.178.07.207.07.431 0 .639C20.577 16.49 16.64 19.5 12 19.5c-4.638 0-8.573-3.007-9.963-7.178z" />
+							<path stroke-linecap="round" stroke-linejoin="round" d="M15 12a3 3 0 11-6 0 3 3 0 016 0z" />
+						</svg>
+						<svg *ngIf="showPassword" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-5 h-5">
+							<path stroke-linecap="round" stroke-linejoin="round" d="M3.98 8.223A10.477 10.477 0 001.934 12C3.226 16.338 7.244 19.5 12 19.5c.993 0 1.953-.138 2.863-.395M6.228 6.228A10.45 10.45 0 0112 4.5c4.756 0 8.773 3.162 10.065 7.498a10.523 10.523 0 01-4.293 5.774M6.228 6.228L3 3m3.228 3.228l3.65 3.65m7.894 7.894L21 21m-3.228-3.228l-3.65-3.65m0 0a3 3 0 10-4.243-4.243m4.242 4.242L9.88 9.88" />
+						</svg>
+					</button>
+				</div>
 			</label>
 			<button class="primary" type="submit" [disabled]="loading">{{ loading ? 'Logging in...' : 'Log in' }}</button>
 		</form>

--- a/src/frontend/src/app/login/login.component.spec.ts
+++ b/src/frontend/src/app/login/login.component.spec.ts
@@ -1,0 +1,48 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { provideRouter } from '@angular/router';
+import { LoginComponent } from './login.component';
+import { AuthService } from '../services/auth.service';
+
+class MockAuthService {
+  getClient() {
+    return {
+      signIn: {
+        email: () => Promise.resolve({}),
+        social: () => Promise.resolve({})
+      }
+    };
+  }
+  refreshSession() { return Promise.resolve(); }
+}
+
+describe('LoginComponent', () => {
+  let component: LoginComponent;
+  let fixture: ComponentFixture<LoginComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [LoginComponent],
+      providers: [
+        provideRouter([]),
+        { provide: AuthService, useClass: MockAuthService }
+      ]
+    })
+    .compileComponents();
+
+    fixture = TestBed.createComponent(LoginComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+
+  it('should toggle password visibility', () => {
+    expect(component.showPassword).toBe(false);
+    component.togglePassword();
+    expect(component.showPassword).toBe(true);
+    component.togglePassword();
+    expect(component.showPassword).toBe(false);
+  });
+});

--- a/src/frontend/src/app/login/login.component.ts
+++ b/src/frontend/src/app/login/login.component.ts
@@ -14,6 +14,7 @@ import { AuthService } from '../services/auth.service';
 export class LoginComponent {
   email = '';
   password = '';
+  showPassword = false;
   error = '';
   loading = false;
 
@@ -65,5 +66,9 @@ export class LoginComponent {
       console.error(err);
       this.loading = false;
     }
+  }
+
+  togglePassword() {
+    this.showPassword = !this.showPassword;
   }
 }

--- a/src/frontend/src/app/register/register.component.html
+++ b/src/frontend/src/app/register/register.component.html
@@ -30,7 +30,18 @@
 			</label>
 			<label class="field">
 				<span>Password</span>
-				<input type="password" name="password" [(ngModel)]="password" placeholder="Create a strong password" autocomplete="new-password" required [disabled]="loading">
+				<div class="relative w-full">
+					<input [type]="showPassword ? 'text' : 'password'" name="password" [(ngModel)]="password" placeholder="Create a strong password" autocomplete="new-password" required [disabled]="loading" class="w-full">
+					<button type="button" (click)="togglePassword()" [attr.aria-label]="showPassword ? 'Hide password' : 'Show password'" class="absolute right-3 top-1/2 -translate-y-1/2 bg-transparent border-0 cursor-pointer text-slate-400/60 p-1">
+						<svg *ngIf="!showPassword" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-5 h-5">
+							<path stroke-linecap="round" stroke-linejoin="round" d="M2.036 12.322a1.012 1.012 0 010-.639C3.423 7.51 7.36 4.5 12 4.5c4.638 0 8.573 3.007 9.963 7.178.07.207.07.431 0 .639C20.577 16.49 16.64 19.5 12 19.5c-4.638 0-8.573-3.007-9.963-7.178z" />
+							<path stroke-linecap="round" stroke-linejoin="round" d="M15 12a3 3 0 11-6 0 3 3 0 016 0z" />
+						</svg>
+						<svg *ngIf="showPassword" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-5 h-5">
+							<path stroke-linecap="round" stroke-linejoin="round" d="M3.98 8.223A10.477 10.477 0 001.934 12C3.226 16.338 7.244 19.5 12 19.5c.993 0 1.953-.138 2.863-.395M6.228 6.228A10.45 10.45 0 0112 4.5c4.756 0 8.773 3.162 10.065 7.498a10.523 10.523 0 01-4.293 5.774M6.228 6.228L3 3m3.228 3.228l3.65 3.65m7.894 7.894L21 21m-3.228-3.228l-3.65-3.65m0 0a3 3 0 10-4.243-4.243m4.242 4.242L9.88 9.88" />
+						</svg>
+					</button>
+				</div>
 			</label>
 			<div class="consent">
 				<input id="consent" type="checkbox" name="consent" [(ngModel)]="consent" required [disabled]="loading">

--- a/src/frontend/src/app/register/register.component.spec.ts
+++ b/src/frontend/src/app/register/register.component.spec.ts
@@ -1,0 +1,50 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { provideRouter } from '@angular/router';
+import { RegisterComponent } from './register.component';
+import { AuthService } from '../services/auth.service';
+
+class MockAuthService {
+  getClient() {
+    return {
+      signUp: {
+        email: () => Promise.resolve({})
+      },
+      signIn: {
+        social: () => Promise.resolve({})
+      }
+    };
+  }
+  refreshSession() { return Promise.resolve(); }
+}
+
+describe('RegisterComponent', () => {
+  let component: RegisterComponent;
+  let fixture: ComponentFixture<RegisterComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [RegisterComponent],
+      providers: [
+        provideRouter([]),
+        { provide: AuthService, useClass: MockAuthService }
+      ]
+    })
+    .compileComponents();
+
+    fixture = TestBed.createComponent(RegisterComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+
+  it('should toggle password visibility', () => {
+    expect(component.showPassword).toBe(false);
+    component.togglePassword();
+    expect(component.showPassword).toBe(true);
+    component.togglePassword();
+    expect(component.showPassword).toBe(false);
+  });
+});

--- a/src/frontend/src/app/register/register.component.ts
+++ b/src/frontend/src/app/register/register.component.ts
@@ -15,6 +15,7 @@ export class RegisterComponent {
   name = '';
   email = '';
   password = '';
+  showPassword = false;
   consent = false;
   error = '';
   loading = false;
@@ -73,5 +74,9 @@ export class RegisterComponent {
       console.error(err);
       this.loading = false;
     }
+  }
+
+  togglePassword() {
+    this.showPassword = !this.showPassword;
   }
 }


### PR DESCRIPTION
💡 **What:** Added a password visibility toggle (eye icon) to the Login and Register screens.
🎯 **Why:** To improve user experience by allowing users to verify their password input before submission, reducing login/registration errors.
📸 **Before/After:** The password field now includes an interactive eye icon that toggles the input type between 'password' and 'text'.
♿ **Accessibility:** Added `aria-label` to the toggle button which updates dynamically ("Show password" / "Hide password") for screen readers.

This change also includes fixes for the `HomeComponent` tests to ensure a clean build.

---
*PR created automatically by Jules for task [23054515523781449](https://jules.google.com/task/23054515523781449) started by @baitimus*